### PR TITLE
Add: Feedbacks

### DIFF
--- a/src/managers/EventsManager.ts
+++ b/src/managers/EventsManager.ts
@@ -9,7 +9,7 @@ export class EventsManager extends BaseManager {
 
 	async get(target: number): Promise<Event | null> {
 		const res = await this.client.get("events/" + target);
-		return new Event(res?.data);
+		return new Event(this.client, res?.data);
 	}
 
 	async fetch(options?: {
@@ -20,6 +20,6 @@ export class EventsManager extends BaseManager {
 			"events/?" + options?.params?.join("&"),
 			options?.limit
 		);
-		return res.map((e) => new Event(<IEvent>e));
+		return res.map((e) => new Event(this.client, <IEvent>e));
 	}
 }

--- a/src/managers/ScaleTeamsManager.ts
+++ b/src/managers/ScaleTeamsManager.ts
@@ -21,12 +21,12 @@ export class ScaleTeamsManager extends BaseManager {
 	}
 
 	/**
-	 * Look for one scal team
-	 * @param  {string} login
+	 * Look for one scale team
+	 * @param  {string} id
 	 * @returns Promise
 	 */
-	async get(login: string): Promise<ScaleTeam | null> {
-		const res = await this.client.get("scale_teams/" + login);
+	async get(id: number): Promise<ScaleTeam | null> {
+		const res = await this.client.get("scale_teams/" + id);
 		if (res === null) return null;
 		return new ScaleTeam(res?.data);
 	}

--- a/src/managers/ScaleTeamsManager.ts
+++ b/src/managers/ScaleTeamsManager.ts
@@ -1,0 +1,33 @@
+import { BaseManager } from "./BaseManager";
+import { Client } from "../structures/client";
+import { ScaleTeam, IScaleTeam } from "../structures/scale_teams";
+
+export class ScaleTeamsManager extends BaseManager {
+	constructor(client: Client) {
+		super(client);
+	}
+
+	/**
+	 * Look for an array of scale teams
+	 * @param  {{limit?:number;params:string[]}} options?
+	 * @returns Promise
+	 */
+	async fetch(options?: { limit?: number; params: string[] }): Promise<ScaleTeam[]> {
+		const res = await this.client.fetch(
+			"scale_teams/?" + options?.params.join("&"),
+			options?.limit
+		);
+		return res.map((o) => new ScaleTeam(<IScaleTeam>o));
+	}
+
+	/**
+	 * Look for one scal team
+	 * @param  {string} login
+	 * @returns Promise
+	 */
+	async get(login: string): Promise<ScaleTeam | null> {
+		const res = await this.client.get("scale_teams/" + login);
+		if (res === null) return null;
+		return new ScaleTeam(res?.data);
+	}
+}

--- a/src/structures/client.ts
+++ b/src/structures/client.ts
@@ -8,6 +8,7 @@ import { Loader } from "../utils/loader";
 import { EventsUsersManager } from "../managers/EventsUsersManager";
 import { CursusManager } from "../managers/CursusManager";
 import { ProjectManager } from "../managers/ProjectManager";
+import { ScaleTeamsManager } from "../managers/ScaleTeamsManager";
 
 const limiter = new Bottleneck({
 	maxConcurrent: 2,
@@ -26,6 +27,7 @@ export class Client {
 	events_users = new EventsUsersManager(this);
 	cursus = new CursusManager(this);
 	projects = new ProjectManager(this);
+	scale_teams = new ScaleTeamsManager(this);
 
 	constructor(id: string, secret: string) {
 		this._id = id;

--- a/src/structures/events.ts
+++ b/src/structures/events.ts
@@ -1,3 +1,6 @@
+import { BaseManager } from "../managers/BaseManager";
+import { Client } from "./client";
+
 export interface IEvent {
 	id: number;
 	name: string;
@@ -17,7 +20,7 @@ export interface IEvent {
 	themes: any[];
 }
 
-export class Event implements IEvent {
+export class Event extends BaseManager implements IEvent  {
 	id: number;
 	name: string;
 	description: string;
@@ -35,7 +38,8 @@ export class Event implements IEvent {
 	waitlist: any;
 	themes: any[];
 
-	constructor(data: IEvent) {
+	constructor(client: Client, data: IEvent) {
+		super(client);
 		this.id = data.id;
 		this.name = data.name;
 		this.description = data.description;
@@ -50,5 +54,12 @@ export class Event implements IEvent {
 		this.created_at = data.created_at;
 		this.updated_at = data.updated_at;
 		this.themes = data.themes;
+	}
+
+	get feedbacks(): Promise<void | object[]> {
+		const ret = this.client
+			.fetch("events/" + this.id + "/feedbacks?")
+			.catch(console.error);
+		return ret;
 	}
 }

--- a/src/structures/feedback_details.ts
+++ b/src/structures/feedback_details.ts
@@ -1,0 +1,5 @@
+export interface IFeedbackDetails {
+    id: number,
+    rate: number,
+    kind: string
+}

--- a/src/structures/feedbacks.ts
+++ b/src/structures/feedbacks.ts
@@ -1,0 +1,13 @@
+import { IFeedbackDetails } from "./feedback_details";
+import { IUser } from "./user";
+
+export interface IFeedback {
+    id: number,
+    user: IUser,
+    feedbackable_type: string,
+    feedbackable_id: number,
+    comment: string,
+    rating: number,
+    created_at: Date,
+    feedback_details: IFeedbackDetails[]
+}

--- a/src/structures/projects_users.ts
+++ b/src/structures/projects_users.ts
@@ -1,5 +1,5 @@
 import { IProject } from "./project";
-import { ITeams } from "./teams";
+import { ITeam } from "./teams";
 
 export interface IProjectsUsers {
     id: number,
@@ -8,5 +8,5 @@ export interface IProjectsUsers {
     status: string,
     project: IProject,
     cursus_ids: number[],
-    teams: ITeams[]
+    teams: ITeam[]
 }

--- a/src/structures/scale_teams.ts
+++ b/src/structures/scale_teams.ts
@@ -1,0 +1,23 @@
+import { IFeedback } from "./feedbacks";
+import { ITeam } from "./teams";
+import { IUser } from "./user";
+
+export interface IScaleTeam {
+    id: number,
+    scale_id: number,
+    comment: string,
+    created_at: string,
+    updated_at: string,
+    feedback: string,
+    finale_mark: number,
+    flag: Object,
+    begin_at: Date,
+    correcteds: IUser[],
+    corrector: IUser,
+    truant: Object,
+    filled_at: Date,
+    questions_with_answers: Object[],
+    scale: Object,
+    team: ITeam,
+    feedbacks: IFeedback[]
+}

--- a/src/structures/scale_teams.ts
+++ b/src/structures/scale_teams.ts
@@ -21,3 +21,43 @@ export interface IScaleTeam {
     team: ITeam,
     feedbacks: IFeedback[]
 }
+
+export class ScaleTeam implements IScaleTeam{
+	id: number;
+    scale_id: number;
+    comment: string;
+    created_at: string;
+    updated_at: string;
+    feedback: string;
+    finale_mark: number;
+    flag: Object;
+    begin_at: Date;
+    correcteds: IUser[];
+    corrector: IUser;
+    truant: Object;
+    filled_at: Date;
+    questions_with_answers: Object[];
+    scale: Object;
+    team: ITeam;
+    feedbacks: IFeedback[];
+
+	constructor(data: IScaleTeam) {
+		this.id = data.id;
+        this.scale_id = data.scale_id;
+        this.comment = data.comment;
+        this.created_at = data.created_at;
+        this.updated_at = data.updated_at;
+        this.feedback = data.feedback;
+        this.finale_mark = data.finale_mark;
+        this.flag = data.flag;
+        this.begin_at = data.begin_at;
+        this.correcteds = data.correcteds;
+        this.corrector = data.corrector;
+        this.truant = data.truant;
+        this.filled_at = data.filled_at;
+        this.questions_with_answers = data.questions_with_answers;
+        this.scale = data.scale;
+        this.team = data.team;
+        this.feedbacks = data.feedbacks;
+	}
+}

--- a/src/structures/teams.ts
+++ b/src/structures/teams.ts
@@ -1,6 +1,6 @@
 import { User } from "./user";
 
-export interface ITeams {
+export interface ITeam {
     id: number,
     name: string,
     url: string,

--- a/src/structures/user.ts
+++ b/src/structures/user.ts
@@ -1,6 +1,7 @@
 import { BaseManager } from "../managers/BaseManager";
 import { Client } from "./client";
 import { ICursusUsers } from "./cursus_users";
+import { IScaleTeam, ScaleTeam } from "./scale_teams";
 
 export interface IUser {
 	id: number;
@@ -134,4 +135,25 @@ export class User extends BaseManager {
 			.catch(console.error);
 		return ret;
 	}
+
+	/**
+	 * Look for an array of scale teams that the user is in
+	 * @param  {{limit?:number;params:string[]}} options basic fetch options
+	 * @param  {number} type 0 for all, 1 for "as corrector", 2 for "as corrected"
+	 * @returns Promise
+	 */
+	async scale_teams(options?: {
+		limit?: number;
+		params: string[];
+	}, type: number = 0): Promise<ScaleTeam[]> {
+		let url = "/users/" + this.id + "/scale_teams";
+		if(type === 1)
+			url += "/as_corrector";
+		if(type === 2)
+			url += "/as_corrected";
+		url += "?" + options?.params.join("&");
+		const res = await this.client.fetch(url, options?.limit);
+		return res.map((o) => new ScaleTeam(<IScaleTeam>o));
+	}
+
 }


### PR DESCRIPTION
Ajout des 2 types de feedbakcs

Les feedbacks d'event sont récupérables directement depuis la class event (d'où l'ajout du client à l'intérieur de celle-ci)

Les scale_teams et leur manager ont été ajoutées pour pourvoir récupérer les feedbacks de celles-ci. Elles sont récuperables depuis leur manager ou directement depuis la class user